### PR TITLE
feat: add support to change width and height sizes from CMS [render preview]

### DIFF
--- a/shared/react-components/src/sections/AboutUsSection/index.tsx
+++ b/shared/react-components/src/sections/AboutUsSection/index.tsx
@@ -46,6 +46,8 @@ export interface AboutUsSectionProps {
     }
   };
   description: ReactNode;
+  logoHeight: number;
+  logoWidth: number;
 }
 
 const iconsByName: Record<string, typeof HandShake> = {
@@ -59,12 +61,12 @@ export default function AboutUsSection({
   statistics,
   description,
   logo,
-  ourValues
+  ourValues,
+  logoHeight,
+  logoWidth
 }: Readonly<AboutUsSectionProps>) {
-
   const items: InfoStackGroupItem[] = ourValues.fields.coreValues.map(({ fields, sys }, index) => {
     const { iconName, title, description } = fields
-
     const Icon = iconsByName[iconName]
 
     return {
@@ -108,9 +110,8 @@ export default function AboutUsSection({
             <img
               src={logo.fields.file.url}
               alt={logo.fields.title}
-              width={215}
-              height={286}
-              className="w-full h-auto"
+              width={logoWidth}
+              height={logoHeight}
             />
           </CardSurface>
 


### PR DESCRIPTION
This pull request introduces updates to the `AboutUsSection` component to make the logo dimensions configurable via props, improving flexibility and reusability. The changes involve adding new properties to the component's interface and updating the rendering logic to use these properties.

### Enhancements to `AboutUsSection` component:

* [`shared/react-components/src/sections/AboutUsSection/index.tsx`](diffhunk://#diff-4b52335266d643872c7404620ede0012a1edfa17168f6b77abff260576bd21d2R49-R50): Added `logoHeight` and `logoWidth` properties to the `AboutUsSectionProps` interface to allow dynamic configuration of logo dimensions.
* [`shared/react-components/src/sections/AboutUsSection/index.tsx`](diffhunk://#diff-4b52335266d643872c7404620ede0012a1edfa17168f6b77abff260576bd21d2L62-L67): Updated the `AboutUsSection` component to accept `logoHeight` and `logoWidth` as props, ensuring they are passed correctly to the component.
* [`shared/react-components/src/sections/AboutUsSection/index.tsx`](diffhunk://#diff-4b52335266d643872c7404620ede0012a1edfa17168f6b77abff260576bd21d2L111-R114): Replaced hardcoded logo dimensions with the new `logoWidth` and `logoHeight` props in the `<img>` element, enabling dynamic sizing.