### PR TITLE
feat: add Organization section and member card components

### DIFF
--- a/apps/new-web/src/widgets/organization/component.tsx
+++ b/apps/new-web/src/widgets/organization/component.tsx
@@ -1,0 +1,1 @@
+export { default } from "react-components/sections/Organization";

--- a/apps/new-web/src/widgets/organization/interface.ts
+++ b/apps/new-web/src/widgets/organization/interface.ts
@@ -1,0 +1,115 @@
+export interface OrganizationPropsDefault {
+  title:          string;
+  speakerProfile: SpeakerProfileDefault[];
+  coreValue:      CoreValueDefault[];
+  description:    string;
+  email:          string;
+}
+
+export interface CoreValueDefault {
+  metadata: Metadata;
+  sys:      CoreValueSys;
+  fields:   CoreValueFields;
+}
+
+export interface CoreValueFields {
+  iconName:    string;
+  title:       string;
+  description: string;
+  url:         string;
+}
+
+export interface Metadata {
+  tags:     any[];
+  concepts: any[];
+}
+
+export interface CoreValueSys {
+  space:            ContentType;
+  id:               string;
+  type:             FluffyType;
+  createdAt:        Date;
+  updatedAt:        Date;
+  environment:      ContentType;
+  publishedVersion: number;
+  revision:         number;
+  contentType?:     ContentType;
+  locale:           Locale;
+}
+
+export interface ContentType {
+  sys: ContentTypeSys;
+}
+
+export interface ContentTypeSys {
+  type:     PurpleType;
+  linkType: LinkType;
+  id:       ID;
+}
+
+export enum ID {
+  CoreValue = "coreValue",
+  Master = "master",
+  S8Dnqsb59Dym = "s8dnqsb59dym",
+  SpeakerProfile = "speakerProfile",
+}
+
+export enum LinkType {
+  ContentType = "ContentType",
+  Environment = "Environment",
+  Space = "Space",
+}
+
+export enum PurpleType {
+  Link = "Link",
+}
+
+export enum Locale {
+  EnUS = "en-US",
+}
+
+export enum FluffyType {
+  Asset = "Asset",
+  Entry = "Entry",
+}
+
+export interface SpeakerProfileDefault {
+  metadata: Metadata;
+  sys:      CoreValueSys;
+  fields:   SpeakerProfileFields;
+}
+
+export interface SpeakerProfileFields {
+  name:  string;
+  role:  string;
+  image: FieldsImage;
+}
+
+export interface FieldsImage {
+  metadata: Metadata;
+  sys:      CoreValueSys;
+  fields:   ImageFields;
+}
+
+export interface ImageFields {
+  title:       string;
+  description: string;
+  file:        File;
+}
+
+export interface File {
+  url:         string;
+  details:     Details;
+  fileName:    string;
+  contentType: string;
+}
+
+export interface Details {
+  size:  number;
+  image: DetailsImage;
+}
+
+export interface DetailsImage {
+  width:  number;
+  height: number;
+}

--- a/apps/new-web/src/widgets/organization/transformer.ts
+++ b/apps/new-web/src/widgets/organization/transformer.ts
@@ -1,2 +1,23 @@
-const transformer = (props: any) => props;
+import { OrganizationProps } from "../../../../../shared/react-components/src/sections/Organization/interface";
+import { CoreValueDefault, OrganizationPropsDefault, SpeakerProfileDefault } from "./interface";
+
+const transformer = (props: OrganizationPropsDefault):OrganizationProps => {
+
+  const newProps = {
+    ...props,
+    speakerProfile: props.speakerProfile.map((speaker: SpeakerProfileDefault) => ({
+      name: speaker.fields.name,
+      role: speaker.fields.role,
+      imageUrl: speaker.fields.image.fields.file.url
+    })),
+    coreValue: props.coreValue.map((value: CoreValueDefault) => ({
+      url: value.fields.url,
+      iconName: value.fields.iconName,
+      title: value.fields.title,
+      description: value.fields.description
+    }))
+  }
+
+  return newProps;
+}
 export default transformer;

--- a/apps/new-web/src/widgets/organization/transformer.ts
+++ b/apps/new-web/src/widgets/organization/transformer.ts
@@ -1,0 +1,2 @@
+const transformer = (props: any) => props;
+export default transformer;

--- a/apps/new-web/src/widgets/organization/transformer.ts
+++ b/apps/new-web/src/widgets/organization/transformer.ts
@@ -1,4 +1,4 @@
-import { OrganizationProps } from "../../../../../shared/react-components/src/sections/Organization/interface";
+import { OrganizationProps } from "react-components/sections/Organization";
 import { CoreValueDefault, OrganizationPropsDefault, SpeakerProfileDefault } from "./interface";
 
 const transformer = (props: OrganizationPropsDefault):OrganizationProps => {

--- a/shared/react-components/package.json
+++ b/shared/react-components/package.json
@@ -68,6 +68,7 @@
     "./sections/Footer": "./src/sections/Footer/index.tsx",
     "./sections/Header": "./src/sections/Header/index.tsx",
     "./sections/SpeakersSection": "./src/sections/SpeakersSection/index.tsx",
-    "./sections/SponsorPricingSection": "./src/sections/SponsorPricingSection/index.tsx"
+    "./sections/SponsorPricingSection": "./src/sections/SponsorPricingSection/index.tsx",
+    "./sections/Organization": "./src/sections/Organization/index.tsx"
   }
 }

--- a/shared/react-components/src/org-member-card/OrganizationMemberCard.stories.tsx
+++ b/shared/react-components/src/org-member-card/OrganizationMemberCard.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta, StoryObj } from '@storybook/react';
+import OrganizationMemberCard from './index';
+
+export default {
+  decorators: [Story => <div className="bg-gray-4 p-12 rounded-md"><Story /></div>],
+  title: 'Molecules/OrganizationMemberCard',
+  component: OrganizationMemberCard,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} as Meta<typeof OrganizationMemberCard>;
+
+type Story = StoryObj<typeof OrganizationMemberCard>;
+
+export const Default: Story = {
+  args: {
+    imageSrc: 'https://picsum.photos/id/238/285/285',
+    name: 'John Doe',
+    role: 'Product Manager',
+  },
+};

--- a/shared/react-components/src/org-member-card/index.tsx
+++ b/shared/react-components/src/org-member-card/index.tsx
@@ -1,0 +1,29 @@
+import Subtitle from '../subtitle';
+import Paragraph from '../paragraph';
+
+export interface SpeakerCardProps {
+  imageSrc: string;
+  name: string;
+  role: string;
+}
+
+export default function OrganizationMemberCard({
+  imageSrc,
+  name,
+  role,
+}: SpeakerCardProps) {
+  return (
+    <article className="flex flex-col gap-2 ">
+      <picture className="rounded-3xl flex justify-center">
+        <img className="rounded-3xl" src={imageSrc} alt={name} width={285} height={285} />
+      </picture>
+
+      <div>
+        <div className="flex flex-col justify-center items-center">
+          <Subtitle className='truncate' weight='medium' size="sm">{name}</Subtitle>
+          <Paragraph color='secondary' size="xl" >{role}</Paragraph>
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/shared/react-components/src/org-member-card/index.tsx
+++ b/shared/react-components/src/org-member-card/index.tsx
@@ -1,7 +1,7 @@
 import Subtitle from '../subtitle';
 import Paragraph from '../paragraph';
 
-export interface SpeakerCardProps {
+export interface OrganizationMemberCardProps {
   imageSrc: string;
   name: string;
   role: string;
@@ -11,7 +11,7 @@ export default function OrganizationMemberCard({
   imageSrc,
   name,
   role,
-}: SpeakerCardProps) {
+}: OrganizationMemberCardProps) {
   return (
     <article className="flex flex-col gap-2 ">
       <picture className="rounded-3xl flex justify-center">

--- a/shared/react-components/src/sections/Organization/index.tsx
+++ b/shared/react-components/src/sections/Organization/index.tsx
@@ -2,49 +2,15 @@ import InstagramIcon from "../../icons/Instagram";
 import LinkedinIcon from "../../icons/Linkedin";
 import OrganizationMemberCard from "../../org-member-card";
 import Paragraph from "../../paragraph";
-import { SocialNetwork } from "../../speaker-card";
+import { OrganizationProps } from "./interface";
 
 const iconsByName: Record<string, typeof InstagramIcon> = {
   "Instagram": InstagramIcon,
   "Linkedin": LinkedinIcon
 }
 
-interface SpeakerProfile {
-  fields: {
-    name: string;
-    role: string;
-    image: {
-      fields: {
-        title: string;
-        file: {
-          url: string;
-        };
-      }
-    },
-    companies: string[];
-    socialNetworks: SocialNetwork[];
-  },
-  sys: {
-    id: string;
-  }
-}
-
-export interface OrganizationProps {
-  title: string;
-  description: string;
-  speakerProfile: SpeakerProfile[];
-  coreValue: {
-    fields: {
-      url: string;
-      iconName: string;
-      title: string;
-      description: string;
-    }
-  }[];
-  email: string;
-}
-
 export default function Organization({ title, description, speakerProfile, coreValue, email }: OrganizationProps) {
+
   return (
     <section className="bg-gray-4">
       <div className="container mx-auto py-16 px-4">
@@ -52,17 +18,17 @@ export default function Organization({ title, description, speakerProfile, coreV
         <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-8">
           {speakerProfile.map((member) => (
             <OrganizationMemberCard
-              key={member.fields.name}
-              name={member.fields.name}
-              role={member.fields.role}
-              imageSrc={member.fields.image.fields.file.url}
+              key={member.name}
+              name={member.name}
+              role={member.role}
+              imageSrc={member.imageUrl}
             />
           ))}
         </div>
         <div className="flex mt-24 justify-between flex-col items-center gap-4 md:flex-row ">
           <Paragraph className="text-button-background-primary" size="xl">{description}</Paragraph>
           <div className="socials flex items-center gap-6">
-            {coreValue.map(({ fields: { url, iconName } }) => {
+            {coreValue.map(({ url, iconName }) => {
               const Icon = iconsByName[iconName];
 
               return (
@@ -73,7 +39,7 @@ export default function Organization({ title, description, speakerProfile, coreV
                   rel="noopener noreferrer"
                   className="text-white"
                 >
-                  {Icon ? <Icon width={32} height={32} /> : null}
+                  {Icon && <Icon width={32} height={32} />}
                 </a>
               );
             })}

--- a/shared/react-components/src/sections/Organization/index.tsx
+++ b/shared/react-components/src/sections/Organization/index.tsx
@@ -1,0 +1,88 @@
+import InstagramIcon from "../../icons/Instagram";
+import LinkedinIcon from "../../icons/Linkedin";
+import OrganizationMemberCard from "../../org-member-card";
+import Paragraph from "../../paragraph";
+import { SocialNetwork } from "../../speaker-card";
+
+const iconsByName: Record<string, typeof InstagramIcon> = {
+  "Instagram": InstagramIcon,
+  "Linkedin": LinkedinIcon
+}
+
+interface SpeakerProfile {
+  fields: {
+    name: string;
+    role: string;
+    image: {
+      fields: {
+        title: string;
+        file: {
+          url: string;
+        };
+      }
+    },
+    companies: string[];
+    socialNetworks: SocialNetwork[];
+  },
+  sys: {
+    id: string;
+  }
+}
+
+export interface OrganizationProps {
+  title: string;
+  description: string;
+  speakerProfile: SpeakerProfile[];
+  coreValue: {
+    fields: {
+      url: string;
+      iconName: string;
+      title: string;
+      description: string;
+    }
+  }[];
+  email: string;
+}
+
+export default function Organization({ title, description, speakerProfile, coreValue, email }: OrganizationProps) {
+  return (
+    <section className="bg-gray-4">
+      <div className="container mx-auto py-16 px-4">
+        <h2 className="text-4xl text-center mb-9 text-white ">{title}</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-8">
+          {speakerProfile.map((member) => (
+            <OrganizationMemberCard
+              key={member.fields.name}
+              name={member.fields.name}
+              role={member.fields.role}
+              imageSrc={member.fields.image.fields.file.url}
+            />
+          ))}
+        </div>
+        <div className="flex mt-24 justify-between flex-col items-center gap-4 md:flex-row ">
+          <Paragraph className="text-button-background-primary" size="xl">{description}</Paragraph>
+          <div className="socials flex items-center gap-6">
+            {coreValue.map(({ fields: { url, iconName } }) => {
+              const Icon = iconsByName[iconName];
+
+              return (
+                <a
+                  key={url}
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-white"
+                >
+                  {Icon ? <Icon width={32} height={32} /> : null}
+                </a>
+              );
+            })}
+            <Paragraph color="primary" size="xl">{email}</Paragraph>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+

--- a/shared/react-components/src/sections/Organization/index.tsx
+++ b/shared/react-components/src/sections/Organization/index.tsx
@@ -51,4 +51,4 @@ export default function Organization({ title, description, speakerProfile, coreV
   )
 }
 
-
+export * from './interface';

--- a/shared/react-components/src/sections/Organization/interface.ts
+++ b/shared/react-components/src/sections/Organization/interface.ts
@@ -1,0 +1,20 @@
+export interface OrganizationProps {
+  title: string;
+  description: string;
+  speakerProfile: SpeakerProfile[];
+  coreValue: CoreValue[];
+  email: string;
+}
+
+export interface SpeakerProfile {
+  name: string;
+  role: string;
+  imageUrl: string;
+}
+
+export interface CoreValue {
+  url: string;
+  iconName: string;
+  title: string;
+  description: string
+}


### PR DESCRIPTION
This pull request introduces a new `Organization` section component, along with related updates to support its functionality. The key changes include the creation of the `Organization` section and its associated components, the addition of a Storybook story for the `OrganizationMemberCard` component, and updates to the module exports for proper integration.

### New `Organization` Section:

* Created the `Organization` section component in `shared/react-components/src/sections/Organization/index.tsx`. This component displays a list of organization members and core values, with support for social network links and email.
* Added an export for the `Organization` section in `shared/react-components/package.json` to make it accessible as a module.

### `OrganizationMemberCard` Component:

* Developed the `OrganizationMemberCard` component in `shared/react-components/src/org-member-card/index.tsx`. This component renders individual organization members with their name, role, and profile image.
* Added a Storybook story for the `OrganizationMemberCard` component in `shared/react-components/src/org-member-card/OrganizationMemberCard.stories.tsx` to showcase its usage and design.

### Integration and Utilities:

* Exported the `Organization` section from `apps/new-web/src/widgets/organization/component.tsx` to integrate it into the application.
* Introduced a placeholder transformer function in `apps/new-web/src/widgets/organization/transformer.ts` to prepare for potential data transformations.