### PR TITLE
feat: enhance SpeakersSection and SpeakerCard components for improved…

### DIFF
--- a/shared/react-components/src/sections/SpeakersSection/index.tsx
+++ b/shared/react-components/src/sections/SpeakersSection/index.tsx
@@ -34,10 +34,10 @@ export default function SpeakersSection({
 
   return (
     <section className="bg-gray-4">
-      <div className="flex flex-col items-center gap-8 container-custom py-12">
+      <div className="flex flex-col items-center gap-8 container-custom py-12 px-4">
         <Subtitle weight="light" size="lg">{title}</Subtitle>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-16 md:gap-5">
           {speakers?.map((speaker) => {
             const socialNetworks: SocialNetwork[] = speaker.socialNetworks.map(({ url, iconName }) => {
               const Icon = iconsByName[iconName]

--- a/shared/react-components/src/speaker-card/Tag.tsx
+++ b/shared/react-components/src/speaker-card/Tag.tsx
@@ -3,7 +3,7 @@ import { createResponsiveStyled } from '@dyesthetics-lab/react-tv-variants-creat
 const Tag = createResponsiveStyled({
   tag: 'span',
   preset: {
-    base: ["inline-block", "rounded-md", "px-3", "py-1", "text-2xl leading-[30px]", "bg-cyan-base"],
+    base: ["inline-block", "rounded-md", "px-3", "text-sm leading-[30px]", "bg-cyan-base"],
     variants: {
     }
   }

--- a/shared/react-components/src/speaker-card/index.tsx
+++ b/shared/react-components/src/speaker-card/index.tsx
@@ -22,15 +22,16 @@ export default function SpeakerCard({
   socialNetworks,
   tags
 }: SpeakerCardProps) {
+
   return (
     <article className="flex flex-col gap-2">
-      <picture className="rounded-3xl w-2xs h-72" >
+      <picture className="rounded-3xl w-72 md:w-56 aspect-square" >
         <img className="rounded-3xl object-cover w-full h-full" src={imageSrc} alt={title} />
       </picture>
 
       <div>
         <div className="flex justify-between items-center">
-          <Subtitle className='truncate' weight='medium' size="md">{title}</Subtitle>
+          <Subtitle className='truncate text-lg' weight='medium'>{title}</Subtitle>
           <div className="flex gap-2">
             {socialNetworks.map(({ url, icon }, index) => (
               <a key={index} href={url} target="_blank" rel="noopener noreferrer">
@@ -40,7 +41,7 @@ export default function SpeakerCard({
           </div>
         </div>
 
-        <Paragraph size="xl" >{description}</Paragraph>
+        <Paragraph size="md" color='secondary' >{description}</Paragraph>
 
         {tags.length > 0 && (
           <div className="mt-3 flex gap-2">


### PR DESCRIPTION
This pull request focuses on improving the responsiveness and design consistency of the speaker-related components in the shared React components library. The changes include updates to layout spacing, typography, and styling for better adaptability across screen sizes and a more polished user interface.

### Layout and Spacing Improvements:
* Updated the `SpeakersSection` layout to include horizontal padding (`px-4`) and adjusted grid column definitions for better responsiveness on medium screens (`md:grid-cols-3`). Additionally, increased the gap between grid items for larger screens (`gap-16`). (`shared/react-components/src/sections/SpeakersSection/index.tsx`, [shared/react-components/src/sections/SpeakersSection/index.tsxL37-R40](diffhunk://#diff-aa63a2b2f7ba000188623f573804240d89927033ae3835e45b515179adac1b58L37-R40))

* Modified the `SpeakerCard` image container to use a square aspect ratio (`aspect-square`) and adjusted width for better responsiveness (`w-72` for base, `md:w-56` for medium screens). (`shared/react-components/src/speaker-card/index.tsx`, [shared/react-components/src/speaker-card/index.tsxR25-R34](diffhunk://#diff-4e4d3b9c944194778c9186ae8ccb6cb3edf9cce4232b3cd5f188093149d4ff22R25-R34))

### Typography and Styling Adjustments:
* Updated the `Tag` component's base styling to use smaller text size (`text-sm`) for better visual balance. (`shared/react-components/src/speaker-card/Tag.tsx`, [shared/react-components/src/speaker-card/Tag.tsxL6-R6](diffhunk://#diff-66c3e48d8c2ca7b5da990227e4bc8bdf2c0baa053db559252f0034324b022887L6-R6))

* Adjusted the `SpeakerCard` title to use a more appropriate text size (`text-lg`) for better visual hierarchy. (`shared/react-components/src/speaker-card/index.tsx`, [shared/react-components/src/speaker-card/index.tsxR25-R34](diffhunk://#diff-4e4d3b9c944194778c9186ae8ccb6cb3edf9cce4232b3cd5f188093149d4ff22R25-R34))

* Changed the `SpeakerCard` description's paragraph size to `md` and added a secondary color for improved readability and consistency. (`shared/react-components/src/speaker-card/index.tsx`, [shared/react-components/src/speaker-card/index.tsxL43-R44](diffhunk://#diff-4e4d3b9c944194778c9186ae8ccb6cb3edf9cce4232b3cd5f188093149d4ff22L43-R44))… layout and styling