### PR TITLE
feat: enhance organization and speakers sections with social networks…

### DIFF
--- a/apps/new-web/src/widgets/organization/interface.ts
+++ b/apps/new-web/src/widgets/organization/interface.ts
@@ -97,8 +97,6 @@ export interface SocialNetworkField {
   url: string;
 }
 
-/*  props.speakerProfile[0].fields.socialNetworks.fields */
-
 export interface FieldsImage {
   metadata: Metadata;
   sys: CoreValueSys;

--- a/apps/new-web/src/widgets/organization/interface.ts
+++ b/apps/new-web/src/widgets/organization/interface.ts
@@ -1,40 +1,40 @@
 export interface OrganizationPropsDefault {
-  title:          string;
+  title: string;
   speakerProfile: SpeakerProfileDefault[];
-  coreValue:      CoreValueDefault[];
-  description:    string;
-  email:          string;
+  coreValue: CoreValueDefault[];
+  description: string;
+  email: string;
 }
 
 export interface CoreValueDefault {
   metadata: Metadata;
-  sys:      CoreValueSys;
-  fields:   CoreValueFields;
+  sys: CoreValueSys;
+  fields: CoreValueFields;
 }
 
 export interface CoreValueFields {
-  iconName:    string;
-  title:       string;
+  iconName: string;
+  title: string;
   description: string;
-  url:         string;
+  url: string;
 }
 
 export interface Metadata {
-  tags:     any[];
+  tags: any[];
   concepts: any[];
 }
 
 export interface CoreValueSys {
-  space:            ContentType;
-  id:               string;
-  type:             FluffyType;
-  createdAt:        Date;
-  updatedAt:        Date;
-  environment:      ContentType;
+  space: ContentType;
+  id: string;
+  type: FluffyType;
+  createdAt: Date;
+  updatedAt: Date;
+  environment: ContentType;
   publishedVersion: number;
-  revision:         number;
-  contentType?:     ContentType;
-  locale:           Locale;
+  revision: number;
+  contentType?: ContentType;
+  locale: Locale;
 }
 
 export interface ContentType {
@@ -42,9 +42,9 @@ export interface ContentType {
 }
 
 export interface ContentTypeSys {
-  type:     PurpleType;
+  type: PurpleType;
   linkType: LinkType;
-  id:       ID;
+  id: ID;
 }
 
 export enum ID {
@@ -75,41 +75,55 @@ export enum FluffyType {
 
 export interface SpeakerProfileDefault {
   metadata: Metadata;
-  sys:      CoreValueSys;
-  fields:   SpeakerProfileFields;
+  sys: CoreValueSys;
+  fields: SpeakerProfileFields;
 }
 
 export interface SpeakerProfileFields {
-  name:  string;
-  role:  string;
+  name: string;
+  role: string[];
   image: FieldsImage;
+  socialNetworks: SocialNetworkDefault[];
 }
+
+export interface SocialNetworkDefault {
+  metadata: Metadata;
+  sys: CoreValueSys;
+  fields: SocialNetworkField;
+}
+
+export interface SocialNetworkField {
+  iconName: string;
+  url: string;
+}
+
+/*  props.speakerProfile[0].fields.socialNetworks.fields */
 
 export interface FieldsImage {
   metadata: Metadata;
-  sys:      CoreValueSys;
-  fields:   ImageFields;
+  sys: CoreValueSys;
+  fields: ImageFields;
 }
 
 export interface ImageFields {
-  title:       string;
+  title: string;
   description: string;
-  file:        File;
+  file: File;
 }
 
 export interface File {
-  url:         string;
-  details:     Details;
-  fileName:    string;
+  url: string;
+  details: Details;
+  fileName: string;
   contentType: string;
 }
 
 export interface Details {
-  size:  number;
+  size: number;
   image: DetailsImage;
 }
 
 export interface DetailsImage {
-  width:  number;
+  width: number;
   height: number;
 }

--- a/apps/new-web/src/widgets/organization/transformer.ts
+++ b/apps/new-web/src/widgets/organization/transformer.ts
@@ -1,23 +1,22 @@
 import { OrganizationProps } from "react-components/sections/Organization";
-import { CoreValueDefault, OrganizationPropsDefault, SpeakerProfileDefault } from "./interface";
+import { OrganizationPropsDefault, SpeakerProfileDefault } from "./interface";
 
-const transformer = (props: OrganizationPropsDefault):OrganizationProps => {
-
+const transformer = (props: OrganizationPropsDefault): OrganizationProps => {
   const newProps = {
     ...props,
-    speakerProfile: props.speakerProfile.map((speaker: SpeakerProfileDefault) => ({
-      name: speaker.fields.name,
-      role: speaker.fields.role,
-      imageUrl: speaker.fields.image.fields.file.url
-    })),
-    coreValue: props.coreValue.map((value: CoreValueDefault) => ({
-      url: value.fields.url,
-      iconName: value.fields.iconName,
-      title: value.fields.title,
-      description: value.fields.description
-    }))
-  }
+    speakerProfile: props.speakerProfile.map(
+      (speaker: SpeakerProfileDefault) => ({
+        name: speaker.fields.name,
+        role: speaker.fields.role,
+        imageUrl: speaker.fields.image.fields.file.url,
+        socialNetworks: speaker.fields.socialNetworks?.map((socialNetwork) => ({
+          iconName: socialNetwork.fields.iconName,
+          url: socialNetwork.fields.url,
+        })),
+      })
+    ),
+  };
 
   return newProps;
-}
+};
 export default transformer;

--- a/apps/new-web/src/widgets/speakers/transformer.ts
+++ b/apps/new-web/src/widgets/speakers/transformer.ts
@@ -4,7 +4,7 @@ interface SocialNetwork {
   fields: {
     iconName: string;
     url: string;
-  }
+  };
 }
 
 interface SpeakerProfile {
@@ -17,24 +17,30 @@ interface SpeakerProfile {
         file: {
           url: string;
         };
-      }
-    },
+      };
+    };
     companies: string[];
     socialNetworks: SocialNetwork[];
-  },
+  };
   sys: {
     id: string;
-  }
+  };
 }
 
 interface TransformerProps {
   title: string;
+  description?: string;
   speakerProfiles: SpeakerProfile[];
 }
 
-const transformer = ({ title, speakerProfiles }: TransformerProps): SpeakersSectionProps => {
+const transformer = ({
+  title,
+  speakerProfiles,
+  description,
+}: TransformerProps): SpeakersSectionProps => {
   const newProps = {
     title,
+    description,
     speakers: speakerProfiles?.map(({ fields, sys }, index) => {
       const { name, role, image, companies, socialNetworks } = fields;
       const imageSrc = image.fields.file.url;
@@ -50,10 +56,10 @@ const transformer = ({ title, speakerProfiles }: TransformerProps): SpeakersSect
         socialNetworks: socialNetworks?.map(({ fields }) => ({
           url: fields.url,
           iconName: fields.iconName,
-        }))
+        })),
       };
     }),
-  }
+  };
 
   return newProps;
 };

--- a/shared/react-components/src/org-member-card/index.tsx
+++ b/shared/react-components/src/org-member-card/index.tsx
@@ -1,29 +1,51 @@
 import Subtitle from '../subtitle';
 import Paragraph from '../paragraph';
 
+import { SocialNetwork } from '../speaker-card';
+
 export interface OrganizationMemberCardProps {
-  imageSrc: string;
+  imageUrl: string;
   name: string;
-  role: string;
+  role: string[];
+  socialNetworks?: SocialNetwork[] | undefined;
 }
 
 export default function OrganizationMemberCard({
-  imageSrc,
+  imageUrl,
   name,
   role,
+  socialNetworks
 }: OrganizationMemberCardProps) {
+
   return (
-    <article className="flex flex-col gap-2 ">
+    <article className="flex flex-col gap-2 justify-start">
       <picture className="rounded-3xl flex justify-center">
-        <img className="rounded-3xl" src={imageSrc} alt={name} width={285} height={285} />
+        <img className="rounded-3xl" src={imageUrl} alt={name} width={285} height={285} />
       </picture>
 
-      <div>
-        <div className="flex flex-col justify-center items-center">
-          <Subtitle className='truncate text-lg' weight='medium'>{name}</Subtitle>
-          <Paragraph color='secondary' size="md" >{role}</Paragraph>
+      <div className="flex flex-col justify-center xl:items-start items-center gap-2 xl:gap-3">
+
+        <Subtitle className='truncate text-lg text-left' weight='medium'>{name}</Subtitle>
+        <div className=' flex flex-col gap-2 sm:h-[42px] '>
+          {
+            role?.map((roleText, index) => (
+              <Paragraph key={index} size="md" color='secondary' className='truncate text-center xl:text-left'>
+                {roleText}
+              </Paragraph>
+            ))
+          }
         </div>
+
+        <div className="w-full flex gap-2 justify-center xl:justify-start items-center">
+          {socialNetworks && socialNetworks.map(({ url, icon }, index) => (
+            <a key={index} href={url} target="_blank" rel="noopener noreferrer">
+              {icon}
+            </a>
+          ))}
+        </div>
+
       </div>
-    </article>
+
+    </article >
   );
 };

--- a/shared/react-components/src/sections/Header/index.tsx
+++ b/shared/react-components/src/sections/Header/index.tsx
@@ -57,7 +57,7 @@ export default function Header({
         className="mobile-navbar top-16 fixed left-0 w-full z-10 text-white bg-gray-4 text-center py-4 transition-transform duration-300 -translate-y-full peer-checked:translate-y-0 flex flex-col gap-0 sm:hidden"
       >
         {navItems.map(({ href, text, variant }, index) => (
-          <Fragment key={href+index}>
+          <Fragment key={href + index}>
             <Button
 
               as="a"

--- a/shared/react-components/src/sections/Organization/index.tsx
+++ b/shared/react-components/src/sections/Organization/index.tsx
@@ -1,5 +1,19 @@
 import OrganizationMemberCard from "../../org-member-card";
 import { OrganizationProps } from 'react-components/sections/Organization';
+import TwitterIcon from '../../icons/Twitter';
+import InstagramIcon from '../../icons/Instagram';
+import LinkedinIcon from '../../icons/Linkedin';
+
+export interface SocialNetwork {
+  url: string;
+  icon: React.ReactNode;
+}
+
+const iconsByName: Record<string, typeof TwitterIcon> = {
+  "Twitter": TwitterIcon,
+  "Instagram": InstagramIcon,
+  "Linkedin": LinkedinIcon
+}
 
 export default function Organization({ title, speakerProfile }: OrganizationProps) {
 
@@ -8,14 +22,27 @@ export default function Organization({ title, speakerProfile }: OrganizationProp
       <div className="container mx-auto py-16 px-4">
         <h2 className="text-4xl text-center mb-9 text-white ">{title}</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-7 gap-8">
-          {speakerProfile?.map((member) => (
-            <OrganizationMemberCard
-              key={member.name}
-              name={member.name}
-              role={member.role}
-              imageSrc={member.imageUrl}
-            />
-          ))}
+          {speakerProfile?.map((member) => {
+            const { name, imageUrl, role } = member
+            const socialNetworks: SocialNetwork[] | undefined = member.socialNetworks?.map(({ url, iconName }) => {
+              const Icon = iconsByName[iconName]
+              return {
+                url,
+                icon: Icon ? <Icon /> : null
+              }
+            })
+
+            return (
+              <OrganizationMemberCard
+                key={name}
+                imageUrl={imageUrl}
+                name={name}
+                role={role}
+                socialNetworks={socialNetworks}
+              />
+            )
+          })}
+
         </div>
       </div>
     </section>

--- a/shared/react-components/src/sections/Organization/interface.ts
+++ b/shared/react-components/src/sections/Organization/interface.ts
@@ -5,6 +5,12 @@ export interface OrganizationProps {
 
 export interface SpeakerProfile {
   name: string;
-  role: string;
+  role: string[];
   imageUrl: string;
+  socialNetworks?: SocialNetwork[];
+}
+
+export interface SocialNetwork {
+  iconName: string;
+  url: string;
 }

--- a/shared/react-components/src/sections/SpeakersSection/index.tsx
+++ b/shared/react-components/src/sections/SpeakersSection/index.tsx
@@ -3,6 +3,7 @@ import SpeakerCard, { SocialNetwork } from '../../speaker-card';
 import TwitterIcon from '../../icons/Twitter';
 import InstagramIcon from '../../icons/Instagram';
 import LinkedinIcon from '../../icons/Linkedin';
+import Paragraph from '../../paragraph';
 
 export interface Speaker {
   id: string;
@@ -19,6 +20,7 @@ export interface Speaker {
 export interface SpeakersSectionProps {
   speakers: Speaker[];
   title?: string;
+  description?: string;
 }
 
 const iconsByName: Record<string, typeof TwitterIcon> = {
@@ -29,6 +31,7 @@ const iconsByName: Record<string, typeof TwitterIcon> = {
 
 export default function SpeakersSection({
   speakers,
+  description,
   title = "Speakers"
 }: Readonly<SpeakersSectionProps>) {
 
@@ -37,7 +40,14 @@ export default function SpeakersSection({
       <div className="flex flex-col items-center gap-8 container-custom py-12 px-4">
         <Subtitle weight="light" size="lg">{title}</Subtitle>
 
+        <div className='w-2/3 te'>
+          <Paragraph className='text-center' weight='light'>
+            {description}
+          </Paragraph>
+        </div>
+
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-16 md:gap-5">
+
           {speakers?.map((speaker) => {
             const socialNetworks: SocialNetwork[] = speaker.socialNetworks.map(({ url, iconName }) => {
               const Icon = iconsByName[iconName]


### PR DESCRIPTION
This pull request introduces enhancements to the handling of speaker profiles and organization member cards by adding support for multiple roles and social network links. It also improves the structure and styling of the components involved. The most important changes are grouped below by theme.

### Enhancements to Speaker Profiles and Social Networks:
* Updated `SpeakerProfileFields` in `apps/new-web/src/widgets/organization/interface.ts` to allow multiple roles (`role: string[]`) and added `socialNetworks` with a new `SocialNetworkDefault` interface.
* Modified the `transformer` function in `apps/new-web/src/widgets/organization/transformer.ts` to map social networks and handle multiple roles for speakers.
* Updated `SpeakerProfile` and `SocialNetwork` interfaces in `apps/new-web/src/widgets/speakers/transformer.ts` to support multiple roles and social networks. [[1]](diffhunk://#diff-d02843cb730f8517f0ff1bb7d959459096e906d3ff76929c57895caf76798f0dL7-R7) [[2]](diffhunk://#diff-d02843cb730f8517f0ff1bb7d959459096e906d3ff76929c57895caf76798f0dL20-R43)

### Organization Member Card Updates:
* Enhanced `OrganizationMemberCard` in `shared/react-components/src/org-member-card/index.tsx` to display multiple roles and social network icons dynamically.
* Added logic in `shared/react-components/src/sections/Organization/index.tsx` to map `iconName` to corresponding social network icons (`Twitter`, `Instagram`, `LinkedIn`) and pass them to `OrganizationMemberCard`. [[1]](diffhunk://#diff-ff6d708b591318aa2a287a4e1479e66ed0bc0c77f578fb68972ca6c42d4583c9R3-R16) [[2]](diffhunk://#diff-ff6d708b591318aa2a287a4e1479e66ed0bc0c77f578fb68972ca6c42d4583c9L11-R45)

### Speakers Section Enhancements:
* Updated `SpeakersSectionProps` in `shared/react-components/src/sections/SpeakersSection/index.tsx` to include an optional `description` field and display it in the section. [[1]](diffhunk://#diff-aa63a2b2f7ba000188623f573804240d89927033ae3835e45b515179adac1b58R23) [[2]](diffhunk://#diff-aa63a2b2f7ba000188623f573804240d89927033ae3835e45b515179adac1b58R43-R50)
* Added logic to map `iconName` to social network icons for speakers, similar to the organization section. [[1]](diffhunk://#diff-aa63a2b2f7ba000188623f573804240d89927033ae3835e45b515179adac1b58R6) [[2]](diffhunk://#diff-aa63a2b2f7ba000188623f573804240d89927033ae3835e45b515179adac1b58R34)

These changes collectively improve the flexibility and user experience of the speaker and organization components by introducing support for richer data and dynamic rendering.… support and improved layout