### PR TITLE
feat: add enterprise mail contactme [render preview]

### DIFF
--- a/apps/new-web/src/widgets/sponsorPricing/transformer.ts
+++ b/apps/new-web/src/widgets/sponsorPricing/transformer.ts
@@ -47,7 +47,7 @@ const transformer = (
   const parser = ctx.get(CustomTemplateParser)
   const parsedDescription = parser.parse(description)
   const parsedEnterpriseContactMe = enterpriseContactMe && parser.parse(enterpriseContactMe)
-  console.log(enterpriseContactMe)
+
   const newProps = {
     title,
     description: parsedDescription,

--- a/apps/new-web/src/widgets/sponsorPricing/transformer.ts
+++ b/apps/new-web/src/widgets/sponsorPricing/transformer.ts
@@ -37,18 +37,21 @@ interface TransformerProps {
   sponsorPackages: SponsorPackage[];
   mediaKitLinks?: MediaKitLink[];
   ctaButton?: CtaButton;
+  enterpriseContactMe?: string;
 }
 
 const transformer = (
-  { description, sponsorPackages, title, mediaKitLinks, ctaButton }: TransformerProps,
+  { description, sponsorPackages, title, mediaKitLinks, ctaButton,enterpriseContactMe }: TransformerProps,
   ctx: ResolutionContext
 ): SponsorPricingSectionProps => {
   const parser = ctx.get(CustomTemplateParser)
   const parsedDescription = parser.parse(description)
-
+  const parsedEnterpriseContactMe = enterpriseContactMe && parser.parse(enterpriseContactMe)
+  console.log(enterpriseContactMe)
   const newProps = {
     title,
     description: parsedDescription,
+    enterpriseContactMe: parsedEnterpriseContactMe,
     pricingTiers: sponsorPackages.map((sponsorPackage) => {
 
       const {

--- a/shared/react-components/src/sections/SponsorPricingSection/index.tsx
+++ b/shared/react-components/src/sections/SponsorPricingSection/index.tsx
@@ -29,6 +29,7 @@ export interface Link {
 export interface SponsorPricingSectionProps {
   title: string;
   description: ReactNode;
+  enterpriseContactMe?: ReactNode;
   pricingTiers: SponsorTier[];
   ctaText?: string;
   ctaHref?: string;
@@ -49,7 +50,8 @@ export default function SponsorPricingSection({
   ctaHref,
   showCta,
   disableCta,
-  mediaKitLinks
+  mediaKitLinks,
+  enterpriseContactMe,
 }: Readonly<SponsorPricingSectionProps>) {
   return (
     <section className='bg-gray-4'>
@@ -117,6 +119,7 @@ export default function SponsorPricingSection({
             <Button disabled={disableCta as any} className='text-center w-fit' as="a" href={ctaHref} size="large" variant='primary'>{ctaText}</Button>
           )}
         </div>
+       {enterpriseContactMe && <p className='text-center text-white'>{enterpriseContactMe}</p>}
       </div>
     </section>
   );


### PR DESCRIPTION
This pull request introduces a new optional `enterpriseContactMe` field to the sponsor pricing components, allowing for additional information or a message to be displayed for enterprise users. The changes span updates to the type definitions, the transformer logic, and the rendering of the `SponsorPricingSection` component.

### Addition of `enterpriseContactMe` field:

* **Type Updates**:
  - Added the `enterpriseContactMe` property to the `TransformerProps` interface in `apps/new-web/src/widgets/sponsorPricing/transformer.ts`.
  - Added the `enterpriseContactMe` property to the `SponsorPricingSectionProps` interface in `shared/react-components/src/sections/SponsorPricingSection/index.tsx`.

* **Transformer Logic**:
  - Updated the transformer function in `apps/new-web/src/widgets/sponsorPricing/transformer.ts` to parse the `enterpriseContactMe` field using the `CustomTemplateParser` and include it in the transformed properties.

* **Component Rendering**:
  - Updated the `SponsorPricingSection` component in `shared/react-components/src/sections/SponsorPricingSection/index.tsx` to accept and render the `enterpriseContactMe` field as a paragraph with specific styling, if provided. [[1]](diffhunk://#diff-86238f9e05d76541c5a6debd6fc4cd03872b1d4033eb0a79c1408bc6245b94d1L52-R54) [[2]](diffhunk://#diff-86238f9e05d76541c5a6debd6fc4cd03872b1d4033eb0a79c1408bc6245b94d1R122)