### PR TITLE
chore: update class on the current sponsors section

### DIFF
--- a/shared/react-components/src/sections/CurrentSponsorsSection/index.tsx
+++ b/shared/react-components/src/sections/CurrentSponsorsSection/index.tsx
@@ -52,12 +52,12 @@ export default function CurrentSponsorsSection({
             return (
               <CardSurface variant='primary' className='flex flex-col gap-6 px-8 py-4 items-center' key={`${index}-${sys.id}`}>
                 <Subtitle className='text-center' weight='light' size="lg">{title}</Subtitle>
-                <div className={`flex justify-center ${isCenter ? 'md:justify-center' : "md:md:justify-start"} flex-wrap gap-5 w-full`}>
+                <div className={`flex justify-center items-baseline ${isCenter ? 'md:justify-center' : "md:md:justify-start"} flex-wrap gap-5 w-full`}>
                   {sponsors.map(({ fields, sys }, index) => {
                     const { title, file } = fields;
                     return (
                       <picture key={`${index}-${sys.id}`}>
-                        <img src={file.url} alt={title} width={183} height={100} />
+                        <img src={file.url} alt={title} className='max-h-[80px] max-w-[200px]' />
                       </picture>
                     )
                   })}


### PR DESCRIPTION
This pull request makes adjustments to the layout and styling of the `CurrentSponsorsSection` component to improve alignment and responsiveness.

Styling improvements:

* [`shared/react-components/src/sections/CurrentSponsorsSection/index.tsx`](diffhunk://#diff-e5ed8d55db1acbf4032f2821fe81371ab39d09a5b898c3382276e8837f6ad3a1L55-R60): Added `items-baseline` to the `div` element's class list to improve vertical alignment of sponsor logos.
* [`shared/react-components/src/sections/CurrentSponsorsSection/index.tsx`](diffhunk://#diff-e5ed8d55db1acbf4032f2821fe81371ab39d09a5b898c3382276e8837f6ad3a1L55-R60): Updated the `img` element to include `max-h-[80px] max-w-[200px]` classes, ensuring consistent sizing for sponsor logos.