### PR TITLE
chore: customize style image height and width

### DIFF
--- a/shared/react-components/src/sections/CurrentSponsorsSection/index.tsx
+++ b/shared/react-components/src/sections/CurrentSponsorsSection/index.tsx
@@ -52,12 +52,12 @@ export default function CurrentSponsorsSection({
             return (
               <CardSurface variant='primary' className='flex flex-col gap-6 px-8 py-4 items-center' key={`${index}-${sys.id}`}>
                 <Subtitle className='text-center' weight='light' size="lg">{title}</Subtitle>
-                <div className={`flex justify-center items-baseline ${isCenter ? 'md:justify-center' : "md:md:justify-start"} flex-wrap gap-5 w-full`}>
+                <div className={`flex justify-center ${isCenter ? 'md:justify-center' : "md:md:justify-start"} flex-wrap gap-5 w-full`}>
                   {sponsors.map(({ fields, sys }, index) => {
                     const { title, file } = fields;
                     return (
                       <picture key={`${index}-${sys.id}`}>
-                        <img src={file.url} alt={title} className='max-h-[80px] max-w-[200px]' />
+                        <img src={file.url} alt={title} height={130} width={250} />
                       </picture>
                     )
                   })}


### PR DESCRIPTION
This pull request includes updates to the `CurrentSponsorsSection` component in `index.tsx` to improve layout consistency and image rendering.

Changes to layout and styling:

* Updated the `div` element's class to remove redundant `items-baseline` styling, ensuring consistent alignment across different screen sizes.

Changes to image rendering:

* Modified the `img` element to use explicit `height` and `width` attributes (130px and 250px, respectively) instead of relying on `className` for sizing, improving clarity and control over image dimensions.