### PR TITLE
fix: styles speakers section

### DIFF
--- a/shared/react-components/src/sections/SpeakersSection/index.tsx
+++ b/shared/react-components/src/sections/SpeakersSection/index.tsx
@@ -46,7 +46,7 @@ export default function SpeakersSection({
           </Paragraph>
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-16 md:gap-5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-16 md:gap-12">
 
           {speakers?.map((speaker) => {
             const socialNetworks: SocialNetwork[] = speaker.socialNetworks.map(({ url, iconName }) => {

--- a/shared/react-components/src/speaker-card/index.tsx
+++ b/shared/react-components/src/speaker-card/index.tsx
@@ -25,8 +25,8 @@ export default function SpeakerCard({
 
   return (
     <article className="flex flex-col gap-2">
-      <picture className="rounded-3xl w-72 md:w-56 aspect-square" >
-        <img className="rounded-3xl object-cover w-full h-full" src={imageSrc} alt={title} />
+      <picture>
+        <img className="rounded-3xl object-cover w-72 h-full" src={imageSrc} alt={title} />
       </picture>
 
       <div>


### PR DESCRIPTION
This pull request includes updates to the layout and styling of components in the `SpeakersSection` and `SpeakerCard` to improve design consistency and responsiveness.

### Layout and styling updates:

* [`shared/react-components/src/sections/SpeakersSection/index.tsx`](diffhunk://#diff-aa63a2b2f7ba000188623f573804240d89927033ae3835e45b515179adac1b58L49-R49): Increased the `gap` value for medium-sized screens (`md:gap-12`) in the grid layout to enhance spacing and visual clarity.
* [`shared/react-components/src/speaker-card/index.tsx`](diffhunk://#diff-4e4d3b9c944194778c9186ae8ccb6cb3edf9cce4232b3cd5f188093149d4ff22L28-R29): Adjusted the `picture` element by removing the `rounded-3xl` class and modifying the `img` element to use a fixed width (`w-72`) for better alignment and consistency across screen sizes.