### PR TITLE
feat: add modal component and register content

### DIFF
--- a/apps/new-web/src/globals/identifiers.ts
+++ b/apps/new-web/src/globals/identifiers.ts
@@ -2,4 +2,5 @@ export const enum ContainerIdentifiers {
   IContentfulClient = "IContentfulClient",
   IContentData = "IContentData",
   IGlobalConfig = "IGlobalConfig",
+  CustomTemplateParser = "CustomTemplateParser",
 }

--- a/apps/new-web/src/services/ContentDataContenful.tsx
+++ b/apps/new-web/src/services/ContentDataContenful.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { ContentfulClientApi } from "contentful";
-import { GetPagesSectionOptions, IContentData } from "./IContentData";
+import { GetPagesSectionOptions, GetModalsOptions, IContentData } from "./IContentData";
 import { inject, injectable } from "inversify";
 import { ContainerIdentifiers } from "@/globals/identifiers";
 
@@ -9,6 +9,7 @@ import { ContainerIdentifiers } from "@/globals/identifiers";
 @injectable()
 export class ContentDataContenful implements IContentData {
   private pagesCache: any[] | null = null;
+  private modalsCache: any[] | null = null;
 
   constructor(
     @inject(ContainerIdentifiers.IContentfulClient)
@@ -46,6 +47,26 @@ export class ContentDataContenful implements IContentData {
 
     const { items } = pages;
     this.pagesCache = items;
+
+    return items;
+  }
+
+  async getModals(options: GetModalsOptions<{
+    include?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+  }> = {}): Promise<any[]> {
+    if (this.modalsCache) {
+      return Promise.resolve(this.modalsCache);
+    }
+
+    const { meta = { include: 2 } } = options;
+
+    const modalsData = await this.client.getEntries({
+      content_type: "modal",
+      include: meta.include,
+    });
+
+    const { items } = modalsData;
+    this.modalsCache = items;
 
     return items;
   }

--- a/apps/new-web/src/services/IContentData.ts
+++ b/apps/new-web/src/services/IContentData.ts
@@ -5,8 +5,12 @@ export interface GetPagesSectionOptions<T> {
   meta?: T
 }
 
+export interface GetModalsOptions<T> {
+  meta?: T
+}
 
 export interface IContentData {
   getSectionsBySlug(options: GetPagesSectionOptions<any>): Promise<any[]>;
   getPages(): Promise<any[]>;
+  getModals(options?: GetModalsOptions<any>): Promise<any[]>;
 }

--- a/apps/new-web/src/widgets/currentSponsors/transformer.ts
+++ b/apps/new-web/src/widgets/currentSponsors/transformer.ts
@@ -9,7 +9,7 @@ const transformer = (props: any, ctx: ResolutionContext): CurrentSponsorsSection
 
   return {
     ...props,
-    description
+    description,
   }
 };
 export default transformer;

--- a/apps/new-web/src/widgets/modal/component.tsx
+++ b/apps/new-web/src/widgets/modal/component.tsx
@@ -1,0 +1,1 @@
+export { default } from "react-components/Modal";

--- a/apps/new-web/src/widgets/modal/transformer.ts
+++ b/apps/new-web/src/widgets/modal/transformer.ts
@@ -1,0 +1,19 @@
+import { ResolutionContext } from "inversify";
+import { CustomTemplateParser } from "react-utils";
+
+const transformer = (props: any,  ctx: ResolutionContext) => {
+  const { id, image, title, buttonText, richText } = props;
+
+  const parser = ctx.get(CustomTemplateParser)
+  const parsedRichText = parser.parse(richText);
+
+  return {
+    id,
+    image: image.fields.file.url,
+    title,
+    buttonText,
+    richText:parsedRichText,
+  };
+}
+
+export default transformer;

--- a/shared/react-components/package.json
+++ b/shared/react-components/package.json
@@ -60,6 +60,7 @@
     "./Paragraph": "./src/paragraph/index.tsx",
     "./DevopsDaysLogoIcon": "./src/icons/DevopsDaysLogo.tsx",
     "./Button": "./src/button/index.tsx",
+    "./Modal": "./src/modal/index.tsx",
     "./sections/Hero": "./src/sections/Hero/index.tsx",
     "./sections/AboutUsSection": "./src/sections/AboutUsSection/index.tsx",
     "./sections/AgendaSection": "./src/sections/AgendaSection/index.tsx",

--- a/shared/react-components/src/icons/CloseIcon.tsx
+++ b/shared/react-components/src/icons/CloseIcon.tsx
@@ -1,0 +1,19 @@
+import { SVGProps } from "react"
+const CloseIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    className="size-6"
+    viewBox="0 0 24 24"
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M6 18 18 6M6 6l12 12"
+    />
+  </svg>
+)
+export default CloseIcon

--- a/shared/react-components/src/modal/Modal.stories.tsx
+++ b/shared/react-components/src/modal/Modal.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Modal from './index';
+
+const meta: Meta<typeof Modal> = {
+  title: 'Components/Modal',
+  component: Modal,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    // Aquí podrías agregar controles si el componente tuviera props
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Historia básica del modal
+export const Default: Story = {
+  render: () => (
+    <div className="p-8">
+      <Modal />
+      <label
+        htmlFor="toggle"
+        className="inline-block mt-4 px-4 py-2 bg-blue-500 text-white rounded cursor-pointer hover:bg-blue-600"
+      >
+        Toggle Modal
+      </label>
+    </div>
+  ),
+};
+

--- a/shared/react-components/src/modal/index.tsx
+++ b/shared/react-components/src/modal/index.tsx
@@ -1,0 +1,38 @@
+import Button from "../button";
+import CloseIcon from "../icons/CloseIcon";
+import Subtitle from "../subtitle";
+
+export interface InfoModalProps {
+  id: string;
+  image: string;
+  title: string;
+  buttonText?: string;
+  richText: string;
+  buttonLink?: string;
+}
+
+export default function Modal({ id, image, title, buttonText, richText, buttonLink }: Readonly<InfoModalProps>) {
+
+  return (
+    <div>
+      <input type="checkbox" id={id} className="peer hidden" />
+      <div className="z-50 fixed inset-0 items-center justify-center peer-checked:flex hidden ">
+        <div className="w-[90%] md:max-w-2/3 bg-gray-4 text-white p-6 shadow-lg rounded-2xl p-1 shadow-button-background-tertiary-hover ">
+          <div className="flex justify-end">
+            <label htmlFor={id} className="cursor-pointer">
+              <CloseIcon />
+            </label>
+          </div>
+          <div className="flex flex-col md:flex-row gap-12">
+            <img className="md:w-4/12" src={image} alt={id} />
+            <div className="md:w-4/6 flex flex-col gap-4">
+              <Subtitle size='lg'>{title}</Subtitle>
+              <p>{richText}</p>
+              {buttonText && <Button className="mt-4 max-w-[200px] text-center" variant="primary" as="a" href={buttonLink}>{buttonText}</Button>}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/shared/react-components/src/sections/CurrentSponsorsSection/index.tsx
+++ b/shared/react-components/src/sections/CurrentSponsorsSection/index.tsx
@@ -37,6 +37,7 @@ export default function CurrentSponsorsSection({
   description,
   sponsorTiers,
 }: Readonly<CurrentSponsorsSectionProps>) {
+
   return (
     <section className="bg-gray-5">
       <div className='flex flex-col gap-8 max-w-[1200px] mx-auto px-6 py-[64px]'>
@@ -49,20 +50,25 @@ export default function CurrentSponsorsSection({
         <div className="flex flex-col gap-6">
           {sponsorTiers?.map(({ fields, sys }, index) => {
             const { title, sponsors, isCenter } = fields;
+
             return (
-              <CardSurface variant='primary' className='flex flex-col gap-6 px-8 py-4 items-center' key={`${index}-${sys.id}`}>
-                <Subtitle className='text-center' weight='light' size="lg">{title}</Subtitle>
-                <div className={`flex justify-center ${isCenter ? 'md:justify-center' : "md:md:justify-start"} flex-wrap gap-5 w-full`}>
-                  {sponsors.map(({ fields, sys }, index) => {
-                    const { title, file } = fields;
-                    return (
-                      <picture key={`${index}-${sys.id}`}>
-                        <img src={file.url} alt={title} height={130} width={250} />
-                      </picture>
-                    )
-                  })}
-                </div>
-              </CardSurface>
+              <div key={`${index}-${sys.id}`}>
+                <CardSurface variant='primary' className='flex flex-col gap-6 px-8 py-4 items-center'>
+                  <Subtitle className='text-center' weight='light' size="lg">{title}</Subtitle>
+                  <div className={`flex justify-center ${isCenter ? 'md:justify-center' : "md:md:justify-start"} flex-wrap gap-5 w-full`}>
+                    {sponsors.map(({ fields, sys }, index) => {
+                      const { title, file } = fields;
+                      return (
+                        <label htmlFor={title} className='cursor-pointer' key={`${index}-${sys.id}`}>
+                          <picture>
+                            <img src={file.url} alt={title} height={130} width={250} />
+                          </picture>
+                        </label>
+                      )
+                    })}
+                  </div>
+                </CardSurface>
+              </div>
             )
           })}
         </div>


### PR DESCRIPTION
This pull request introduces support for modal components in the web application, along with updates to the content data service and enhancements to the shared component library. The most significant changes include adding modal-related functionality, updating the `ContentDataContenful` service to fetch modal data, and implementing a new modal component in the shared library.

### Modal Support and Integration

* `apps/new-web/src/app/[[...slug]]/page.tsx`: Updated the `Page` function to fetch and process modal data alongside section data using `Promise.all`. Added rendering logic for modal components, including a development warning for missing modal components. ([apps/new-web/src/app/[[...slug]]/page.tsxL86-R111](diffhunk://#diff-1c45041ed4f8ba19673e6099b22ff9f616cbd28f85e87286e4a380b7026a28c7L86-R111), [apps/new-web/src/app/[[...slug]]/page.tsxR140-R172](diffhunk://#diff-1c45041ed4f8ba19673e6099b22ff9f616cbd28f85e87286e4a380b7026a28c7R140-R172))

* [`shared/react-components/src/modal/index.tsx`](diffhunk://#diff-be20fc82e7943779676459bc8a82e401529e5d7cfba4ee92457bd3d19da5032fR1-R38): Implemented the `Modal` component, which renders modal content including title, rich text, images, and optional buttons. Introduced a toggle mechanism for displaying modals.

* [`shared/react-components/src/modal/Modal.stories.tsx`](diffhunk://#diff-630758e26a9056b421b95563fae221ca2b3b2ade7d1826609696fa591abaf4bbR1-R33): Added a Storybook entry for the `Modal` component to facilitate testing and documentation.

### Content Data Service Enhancements

* [`apps/new-web/src/services/ContentDataContenful.tsx`](diffhunk://#diff-ab413cb75a07a9276809e9ea0b8eadf0105f0d506295731fc0d1eebc1be4a084R54-R73): Added a `getModals` method to fetch modal data from the contentful API, with caching support.

* [`apps/new-web/src/services/IContentData.ts`](diffhunk://#diff-40ab8013fb3f701fcf51046f7f3e0c1de4c642693b7865979f6ef72b2cfc64deR8-R15): Defined a new `GetModalsOptions` interface and updated the `IContentData` interface to include the `getModals` method.

### Shared Component Library Updates

* [`shared/react-components/src/icons/CloseIcon.tsx`](diffhunk://#diff-bc775005ba4a495d29006586c1f7ded6997843d9dba4f6f8b254c1a260d2c3f2R1-R19): Added a reusable `CloseIcon` SVG component for use in modal headers.

* [`shared/react-components/package.json`](diffhunk://#diff-5d7a34c10ad1a1ef90f4e48007552d106c9d3831b655c355e6ca45f0019a1455R63): Registered the new `Modal` component in the shared library's module exports.

These changes collectively enhance the application's ability to display modals dynamically, improve modularity, and expand the shared component library for future use.