### PR TITLE
chore: add buttonLink prop to modal and open link in new tab

### DIFF
--- a/apps/new-web/src/widgets/modal/transformer.ts
+++ b/apps/new-web/src/widgets/modal/transformer.ts
@@ -2,7 +2,7 @@ import { ResolutionContext } from "inversify";
 import { CustomTemplateParser } from "react-utils";
 
 const transformer = (props: any,  ctx: ResolutionContext) => {
-  const { id, image, title, buttonText, richText } = props;
+  const { id, image, title, buttonText, richText,buttonLink } = props;
 
   const parser = ctx.get(CustomTemplateParser)
   const parsedRichText = richText && parser.parse(richText);
@@ -13,6 +13,7 @@ const transformer = (props: any,  ctx: ResolutionContext) => {
     title,
     buttonText,
     richText:parsedRichText,
+    buttonLink
   };
 }
 

--- a/shared/react-components/src/modal/index.tsx
+++ b/shared/react-components/src/modal/index.tsx
@@ -29,7 +29,7 @@ export default function Modal({ id, image, title, buttonText, richText, buttonLi
             <div className="md:w-4/6 flex flex-col gap-4">
               <Subtitle size='lg'>{title}</Subtitle>
               <p>{richText}</p>
-              {buttonText && <Button className="mt-4 max-w-[200px] text-center flex justify-center items-center gap-2" variant="primary" as="a" href={buttonLink}>{buttonText} <ArrowRight /></Button>}
+              {buttonText && <Button className="mt-4 max-w-[200px] text-center flex justify-center items-center gap-2" variant="primary" as="a" href={buttonLink} target="_blank">{buttonText} <ArrowRight /></Button>}
             </div>
           </div>
         </div>


### PR DESCRIPTION
This pull request adds support for an optional `buttonLink` property in the modal component, allowing buttons to include hyperlinks that open in a new tab. The changes primarily affect the modal's transformer logic and rendering behavior.

### Enhancements to modal functionality:

* **Transformer updates in `apps/new-web/src/widgets/modal/transformer.ts`:**
  - Added `buttonLink` to the destructured `props` object in the transformer function.
  - Included `buttonLink` in the transformed output object.

* **Rendering updates in `shared/react-components/src/modal/index.tsx`:**
  - Modified the `Button` component to use the `target="_blank"` attribute when rendering links, ensuring they open in a new tab.