### PR TITLE
feat: add mainImageURL to HeroSectionProps and update transform function

### DIFF
--- a/apps/new-web/src/widgets/hero/transformer.ts
+++ b/apps/new-web/src/widgets/hero/transformer.ts
@@ -16,6 +16,14 @@ interface RawProps {
         url: string;
       }
     }
+  },
+  mainImage: {
+    fields: {
+      title: string;
+      file: {
+        url: string;
+      }
+    }
   }
 }
 
@@ -27,7 +35,7 @@ export default async function transform(
   const globalConfig = await getGlobalConfig.getGlobalConfig()
   const { paymentExternalLink, name } = globalConfig.fields;
 
-  const { logo, ...rest } = rawProps;
+  const { logo, mainImage,...rest } = rawProps;
 
   return {
     ...rest,
@@ -35,5 +43,6 @@ export default async function transform(
     logoTitle: logo.fields.title,
     ctaText: rest.ctaText ?? name,
     ctaHref: rest.ctaHref ?? paymentExternalLink,
+    mainImageURL: mainImage.fields.file.url,
   }
 }

--- a/shared/react-components/src/sections/Hero/index.tsx
+++ b/shared/react-components/src/sections/Hero/index.tsx
@@ -11,6 +11,7 @@ export interface HeroSectionProps {
   logoTitle?: string;
   ctaHref: string;
   showCta?: boolean;
+  mainImageURL?: string;
 }
 
 function formatDate(dateString: string) {
@@ -38,21 +39,17 @@ export default function HeroSection({
   date,
   placeText,
   ctaText,
-  imgURL,
   logoTitle,
   ctaHref,
-  showCta
+  showCta,
+  mainImageURL
 }: Readonly<HeroSectionProps>) {
 
   return (
     <section className='bg-gray-4'>
-      <div className="flex flex-col gap-4 max-w-[1200px] mx-auto px-6 pb-[120px] pt-[80px]">
-        <picture>
-          <img src={imgURL} alt={logoTitle} width={204} height={151} />
-        </picture>
-
+      <div className="flex flex-col-reverse md:flex-row md:items-center gap-4 max-w-[1200px] mx-auto px-6 pb-[120px] pt-[80px]">
         <div className='flex flex-col gap-6'>
-          <h1 className='text-3xl md:text-8xl bg-linear-[90deg,#A150BF,#7B50BF,#2DABD1,#DAF7FB] text-transparent bg-clip-text font-bold'>{title}</h1>
+          <h1 className='text-3xl md:text-6xl lg:text-8xl bg-linear-[90deg,#A150BF,#7B50BF,#2DABD1,#DAF7FB] text-transparent bg-clip-text font-bold'>{title}</h1>
 
           <div>
             <Paragraph className='text-base leading-5 md:text-2xl md:leading-8'>{formatDate(date)}</Paragraph>
@@ -68,6 +65,9 @@ export default function HeroSection({
             )
           }
         </div>
+        <picture>
+          <img src={mainImageURL} alt={logoTitle} className='w-full max-w-[525px] min-w-[344px]' />
+        </picture>
       </div>
     </section>
   );


### PR DESCRIPTION
This pull request introduces support for a new `mainImage` field in the Hero widget, updating both the data transformation logic and the Hero section component to display this image. Key changes include extending the data model, updating the transformer function, and modifying the Hero section layout and props.

### Data Model Updates:
* Added a new `mainImage` field to the `RawProps` interface in `apps/new-web/src/widgets/hero/transformer.ts`, which includes `title` and `file.url` properties.

### Transformer Function Updates:
* Updated the `transform` function in `apps/new-web/src/widgets/hero/transformer.ts` to extract `mainImage` from `rawProps` and include `mainImageURL` in the returned object.

### Hero Component Updates:
* Added a `mainImageURL` optional property to the `HeroSectionProps` interface in `shared/react-components/src/sections/Hero/index.tsx`.
* Modified the `HeroSection` component to accept `mainImageURL` and updated the layout to display the `mainImage` below the text content.
* Adjusted the Hero section's title styling to better accommodate the new layout.