### PR TITLE
feat: add SpeakersDataService and integrate speakers section with mod…

### DIFF
--- a/apps/new-web/src/app/[[...slug]]/page.tsx
+++ b/apps/new-web/src/app/[[...slug]]/page.tsx
@@ -85,6 +85,8 @@ export default async function Page({ params }: PageProps) {
   contentDataService = container.get<IContentData>(ContainerIdentifiers.IContentData);
   if (slugString === "agenda") {
     contentDataService = container.get<IContentData>(ContainerIdentifiers.IAgendaData);
+  } else if (slugString === "speakers") {
+    contentDataService = container.get<IContentData>(ContainerIdentifiers.ISpeakersData);
   }
 
   const [sections, modals] = await Promise.all([

--- a/apps/new-web/src/globals/container.ts
+++ b/apps/new-web/src/globals/container.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 
 import { ContentDataContenful } from "@/services/ContentDataContenful";
 import { AgendaDataService } from "@/services/agenda/AgendaDataService";
+import { SpeakersDataService } from "@/services/speakers/SpeakersDataService";
 import { Container } from "inversify";
 
 import { createClient } from "contentful"
@@ -35,6 +36,11 @@ container
 container
   .bind(ContainerIdentifiers.IAgendaData)
   .to(AgendaDataService)
+  .inSingletonScope();
+
+container
+  .bind(ContainerIdentifiers.ISpeakersData)
+  .to(SpeakersDataService)
   .inSingletonScope();
 
 container

--- a/apps/new-web/src/globals/identifiers.ts
+++ b/apps/new-web/src/globals/identifiers.ts
@@ -4,4 +4,5 @@ export const enum ContainerIdentifiers {
   IGlobalConfig = "IGlobalConfig",
   CustomTemplateParser = "CustomTemplateParser",
   IAgendaData = "IAgendaData",
+  ISpeakersData = "ISpeakersData",
 }

--- a/apps/new-web/src/services/speakers/SpeakersDataService.ts
+++ b/apps/new-web/src/services/speakers/SpeakersDataService.ts
@@ -37,38 +37,40 @@ export class SpeakersDataService implements IContentData {
 
   private extractSpeakersWithTalks(scheduleData: ApiScheduleData): SpeakerWithTalk[] {
     const speakersMap = new Map<string, any>();
+    const talksMap = new Map<string, any>();
     
     scheduleData.speakers.forEach(speaker => {
       speakersMap.set(speaker.code, speaker);
     });
 
-    const speakersWithTalks: SpeakerWithTalk[] = [];
-    const processedSpeakers = new Set<string>();
-
     scheduleData.talks.forEach(talk => {
       if (talk.speakers && talk.speakers.length > 0) {
         talk.speakers.forEach(speakerCode => {
-          if (!processedSpeakers.has(speakerCode)) {
-            const speaker = speakersMap.get(speakerCode);
-            if (speaker) {
-              const talkTitle = typeof talk.title === 'string' 
-                ? talk.title 
-                : talk.title?.es || talk.title?.en || 'Sin título';
-
-              speakersWithTalks.push({
-                id: speaker.code,
-                name: speaker.name,
-                imageSrc: speaker.avatar || speaker.avatar_thumbnail_default || speaker.avatar_thumbnail_tiny || '',
-                talkTitle,
-                talkAbstract: talk.abstract
-              });
-              
-              processedSpeakers.add(speakerCode);
-            }
+          if (!talksMap.has(speakerCode)) {
+            talksMap.set(speakerCode, talk);
           }
         });
       }
     });
+
+    const speakersWithTalks: SpeakerWithTalk[] = [];
+
+    for (const [speakerCode, talk] of talksMap) {
+      const speaker = speakersMap.get(speakerCode);
+      if (speaker) {
+        const talkTitle = typeof talk.title === 'string' 
+          ? talk.title 
+          : talk.title?.es || talk.title?.en || 'Sin título';
+
+        speakersWithTalks.push({
+          id: speaker.code,
+          name: speaker.name,
+          imageSrc: speaker.avatar || speaker.avatar_thumbnail_default || speaker.avatar_thumbnail_tiny || '',
+          talkTitle,
+          talkAbstract: talk.abstract
+        });
+      }
+    }
 
     return speakersWithTalks;
   }

--- a/apps/new-web/src/services/speakers/SpeakersDataService.ts
+++ b/apps/new-web/src/services/speakers/SpeakersDataService.ts
@@ -1,0 +1,119 @@
+import { injectable } from 'inversify';
+import { IContentData, GetPagesSectionOptions, GetModalsOptions } from '../IContentData';
+import { ApiScheduleData, SpeakerWithTalk } from './types';
+
+@injectable()
+export class SpeakersDataService implements IContentData {
+  private scheduleCache: ApiScheduleData | null = null;
+  private readonly apiUrl = 'https://talks.devopsdays.org/devopsdays-lima-2025/schedule/widgets/schedule.json';
+
+  private async fetchScheduleData(): Promise<ApiScheduleData> {
+    if (this.scheduleCache) {
+      return Promise.resolve(this.scheduleCache);
+    }
+
+    try {
+      const response = await fetch(this.apiUrl);
+      if (!response.ok) {
+        throw new Error(`Error fetching schedule data: ${response.statusText}`);
+      }
+      this.scheduleCache = await response.json() as ApiScheduleData;
+      return this.scheduleCache;
+    } catch (error) {
+      console.error('Error fetching schedule data:', error);
+
+      return {
+        talks: [],
+        rooms: [],
+        speakers: [],
+        event_start: '',
+        event_end: '',
+        timezone: '',
+        version: '',
+        tracks: []
+      };
+    }
+  }
+
+  private extractSpeakersWithTalks(scheduleData: ApiScheduleData): SpeakerWithTalk[] {
+    const speakersMap = new Map<string, any>();
+    
+    scheduleData.speakers.forEach(speaker => {
+      speakersMap.set(speaker.code, speaker);
+    });
+
+    const speakersWithTalks: SpeakerWithTalk[] = [];
+    const processedSpeakers = new Set<string>();
+
+    scheduleData.talks.forEach(talk => {
+      if (talk.speakers && talk.speakers.length > 0) {
+        talk.speakers.forEach(speakerCode => {
+          if (!processedSpeakers.has(speakerCode)) {
+            const speaker = speakersMap.get(speakerCode);
+            if (speaker) {
+              const talkTitle = typeof talk.title === 'string' 
+                ? talk.title 
+                : talk.title?.es || talk.title?.en || 'Sin título';
+
+              speakersWithTalks.push({
+                id: speaker.code,
+                name: speaker.name,
+                imageSrc: speaker.avatar || speaker.avatar_thumbnail_default || speaker.avatar_thumbnail_tiny || '',
+                talkTitle,
+                talkAbstract: talk.abstract
+              });
+              
+              processedSpeakers.add(speakerCode);
+            }
+          }
+        });
+      }
+    });
+
+    return speakersWithTalks;
+  }
+
+  async getSectionsBySlug(options: GetPagesSectionOptions<any>): Promise<any[]> {
+    if (options.slug !== 'speakers') {
+      return [];
+    }
+
+    try {
+      const scheduleData = await this.fetchScheduleData();
+      const speakersWithTalks = this.extractSpeakersWithTalks(scheduleData);
+
+      if (speakersWithTalks.length === 0) {
+        return [];
+      }
+
+      const transformedData = {
+        sys: {
+          id: 'speakers-section',
+          contentType: {
+            sys: {
+              id: 'speakers'
+            }
+          }
+        },
+        fields: {
+          speakers: speakersWithTalks,
+          title: 'Speakers',
+          description: 'Conoce a nuestros increíbles speakers del DevOpsDays Lima 2025'
+        }
+      };
+
+      return [transformedData];
+    } catch (error) {
+      console.error('Error transforming speakers data:', error);
+      return [];
+    }
+  }
+
+  async getPages(): Promise<any[]> {
+    return [];
+  }
+
+  async getModals(options?: GetModalsOptions<any>): Promise<any[]> {
+    return [];
+  }
+}

--- a/apps/new-web/src/services/speakers/types.ts
+++ b/apps/new-web/src/services/speakers/types.ts
@@ -1,0 +1,39 @@
+export interface ApiSpeaker {
+  code: string;
+  name: string;
+  avatar?: string;
+  avatar_thumbnail_default?: string;
+  avatar_thumbnail_tiny?: string;
+  bio?: string;
+}
+
+export interface ApiTalk {
+  id: number;
+  title: string | { en: string; es: string };
+  abstract?: string;
+  speakers: string[];
+  start: string;
+  end: string;
+  room: number;
+  duration?: number;
+  code?: string;
+}
+
+export interface ApiScheduleData {
+  talks: ApiTalk[];
+  rooms: any[];
+  speakers: ApiSpeaker[];
+  event_start: string;
+  event_end: string;
+  timezone: string;
+  version: string;
+  tracks: any[];
+}
+
+export interface SpeakerWithTalk {
+  id: string;
+  name: string;
+  imageSrc: string;
+  talkTitle: string;
+  talkAbstract?: string;
+}

--- a/apps/new-web/src/widgets/agenda/api-transformer.ts
+++ b/apps/new-web/src/widgets/agenda/api-transformer.ts
@@ -1,50 +1,59 @@
 import { AgendaProps } from "react-components/sections/AgendaSection";
-import { ApiScheduleData, ApiTalk, ApiRoom, ApiSpeaker } from "@/services/agenda/types";
+import {
+  ApiScheduleData,
+  ApiTalk,
+  ApiRoom,
+  ApiSpeaker,
+} from "@/services/agenda/types";
 import { ResolutionContext } from "inversify";
 
 function transformer(props: any, _ctx: ResolutionContext): AgendaProps {
   return transformApiData(props);
-};
+}
 
 const transformApiData = (data: ApiScheduleData): AgendaProps => {
   if (!data || !data.talks || !data.rooms || data.talks.length === 0) {
     return {
       tabLabels: [],
-      agendaItemsBy: {}
+      agendaItemsBy: {},
     };
   }
 
   const roomsMap = new Map<number, ApiRoom>();
-  data.rooms.forEach(room => {
+  data.rooms.forEach((room) => {
     roomsMap.set(room.id, room);
   });
 
   const speakersMap = new Map<string, ApiSpeaker>();
-  data.speakers.forEach(speaker => {
+  data.speakers.forEach((speaker) => {
     speakersMap.set(speaker.code, speaker);
   });
 
-  const validTalks = data.talks.filter(talk =>
-    talk.room && roomsMap.has(talk.room)
+  const validTalks = data.talks.filter(
+    (talk) => talk.room && roomsMap.has(talk.room)
   );
 
-  const roomsWithTalks = Array.from(new Set(validTalks.map(talk => talk.room)))
-    .map(roomId => roomsMap.get(roomId)!)
+  const roomsWithTalks = Array.from(
+    new Set(validTalks.map((talk) => talk.room))
+  )
+    .map((roomId) => roomsMap.get(roomId)!)
     .filter(Boolean)
     .sort((a, b) => a.id - b.id);
 
   const tabLabels = roomsWithTalks.map((room, index) => {
     let roomName = `Sala ${room.id}`;
-    if (typeof room.name === 'string') {
+    if (typeof room.name === "string") {
       roomName = room.name;
-    } else if (room.name && typeof room.name === 'object') {
+    } else if (room.name && typeof room.name === "object") {
       roomName = room.name.es || room.name.en || `Sala ${room.id}`;
     }
     return String(roomName);
   });
 
   const uniqueTabLabels = tabLabels.map((label, index) => {
-    const duplicateCount = tabLabels.slice(0, index).filter(l => l === label).length;
+    const duplicateCount = tabLabels
+      .slice(0, index)
+      .filter((l) => l === label).length;
     return duplicateCount > 0 ? `${label} (${duplicateCount + 1})` : label;
   });
 
@@ -52,41 +61,46 @@ const transformApiData = (data: ApiScheduleData): AgendaProps => {
 
   roomsWithTalks.forEach((room, index) => {
     const roomTalks = validTalks
-      .filter(talk => talk.room === room.id)
-      .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+      .filter((talk) => talk.room === room.id)
+      .sort(
+        (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
+      );
 
     const roomKey = uniqueTabLabels[index];
-    agendaItemsBy[roomKey] = roomTalks.map(talk => {
-      let title = 'Sin título';
-      if (typeof talk.title === 'string') {
+    agendaItemsBy[roomKey] = roomTalks.map((talk) => {
+      let title = "Sin título";
+      if (typeof talk.title === "string") {
         title = talk.title;
-      } else if (talk.title && typeof talk.title === 'object') {
-        title = talk.title.es || talk.title.en || 'Sin título';
+      } else if (talk.title && typeof talk.title === "object") {
+        title = talk.title.es || talk.title.en || "Sin título";
       }
 
       title = String(title);
 
-      let description = '';
+      let description = "";
       if (talk.speakers && talk.speakers.length > 0) {
         const speakerNames = talk.speakers
-          .map(speakerCode => speakersMap.get(speakerCode)?.name || 'Orador no confirmado')
-          .join(', ');
+          .map(
+            (speakerCode) =>
+              speakersMap.get(speakerCode)?.name || "Orador no confirmado"
+          )
+          .join(", ");
         description = `Presentado por: ${speakerNames}`;
       } else {
-        description = 'Evento general';
+        description = "Evento general";
       }
 
       return {
         date: talk.start,
         title: title,
-        description: description
+        description: description,
       };
     });
   });
 
   return {
     tabLabels: uniqueTabLabels,
-    agendaItemsBy
+    agendaItemsBy,
   };
 };
 

--- a/apps/new-web/src/widgets/speakers/transformer.ts
+++ b/apps/new-web/src/widgets/speakers/transformer.ts
@@ -53,6 +53,7 @@ const isContentfulTransformer = (props: TransformerProps): props is ContentfulTr
   return 'speakerProfiles' in props;
 };
 
+//TODO: Deberías tener un transformer por data source.
 const transformer = (props: TransformerProps): SpeakersSectionProps => {
   const { title, description } = props;
 

--- a/apps/new-web/src/widgets/speakers/transformer.ts
+++ b/apps/new-web/src/widgets/speakers/transformer.ts
@@ -1,5 +1,19 @@
 import type { SpeakersSectionProps } from "react-components/sections/SpeakersSection";
 
+interface SpeakerWithTalk {
+  id: string;
+  name: string;
+  imageSrc: string;
+  talkTitle: string;
+  talkAbstract?: string;
+}
+
+interface ApiTransformerProps {
+  title: string;
+  description?: string;
+  speakers: SpeakerWithTalk[];
+}
+
 interface SocialNetwork {
   fields: {
     iconName: string;
@@ -27,41 +41,56 @@ interface SpeakerProfile {
   };
 }
 
-interface TransformerProps {
+interface ContentfulTransformerProps {
   title: string;
   description?: string;
   speakerProfiles: SpeakerProfile[];
 }
 
-const transformer = ({
-  title,
-  speakerProfiles,
-  description,
-}: TransformerProps): SpeakersSectionProps => {
-  const newProps = {
-    title,
-    description,
-    speakers: speakerProfiles?.map(({ fields, sys }, index) => {
-      const { name, role, image, companies, socialNetworks } = fields;
-      const imageSrc = image.fields.file.url;
+type TransformerProps = ApiTransformerProps | ContentfulTransformerProps;
 
-      const tags = companies?.map((company) => company);
+const isContentfulTransformer = (props: TransformerProps): props is ContentfulTransformerProps => {
+  return 'speakerProfiles' in props;
+};
 
-      return {
-        id: `${index}${sys.id}`,
-        imageSrc,
-        title: name,
-        description: role,
-        tags,
-        socialNetworks: socialNetworks?.map(({ fields }) => ({
-          url: fields.url,
-          iconName: fields.iconName,
-        })),
-      };
-    }),
-  };
+const transformer = (props: TransformerProps): SpeakersSectionProps => {
+  const { title, description } = props;
 
-  return newProps;
+  if (isContentfulTransformer(props)) {
+    const { speakerProfiles } = props;
+
+    return {
+      title,
+      description,
+      speakers: speakerProfiles?.map(({ fields, sys }, index) => {
+        const { name, role, image, companies, socialNetworks } = fields;
+        const imageSrc = image.fields.file.url;
+        const tags = companies?.map((company) => company);
+
+        return {
+           id: `${index}${sys.id}`,
+           imageSrc,
+           name: name,
+           talkTitle: role,
+           talkAbstract: companies?.join(', '),
+         };
+      }),
+    };
+  } else {
+    const { speakers } = props;
+
+    return {
+      title,
+      description,
+      speakers: speakers?.map((speaker) => ({
+        id: speaker.id,
+        imageSrc: speaker.imageSrc,
+        name: speaker.name,
+        talkTitle: speaker.talkTitle,
+        talkAbstract: speaker.talkAbstract,
+      })),
+    };
+  }
 };
 
 export default transformer;

--- a/shared/react-components/src/modal/SpeakerModal.tsx
+++ b/shared/react-components/src/modal/SpeakerModal.tsx
@@ -13,15 +13,15 @@ export const SpeakerModal: React.FC<SpeakerModalProps> = ({ id, imageSrc, name, 
   return (
     <div>
       <input type="checkbox" id={id} className="peer hidden" />
-      <div className="z-50 fixed inset-0 items-center justify-center peer-checked:flex hidden">
-        <div className="w-[90%] md:max-w-4xl bg-gray-4 text-white p-6 shadow-lg rounded-2xl shadow-button-background-tertiary-hover">
+      <div className="z-50 fixed inset-0 items-center justify-center peer-checked:flex hidden bg-[#000000d4]">
+        <div className="w-[90%] md:max-w-4xl bg-gray-4 text-white p-6 shadow-lg rounded-2xl shadow-button-background-tertiary-hover ">
           <div className="flex justify-end">
             <label htmlFor={id} className="cursor-pointer">
               <CloseIcon />
             </label>
           </div>
           <div className="flex flex-col md:flex-row gap-6">
-            {/* Speaker Image */}
+
             <div className="flex-shrink-0">
               <div className="relative w-48 h-48 rounded-lg overflow-hidden bg-gradient-to-br from-blue-500 to-purple-600 shadow-lg mx-auto">
                 {imageSrc ? (

--- a/shared/react-components/src/modal/SpeakerModal.tsx
+++ b/shared/react-components/src/modal/SpeakerModal.tsx
@@ -1,0 +1,73 @@
+import CloseIcon from '../icons/CloseIcon';
+import Subtitle from '../subtitle';
+
+export interface SpeakerModalProps {
+  id: string;
+  imageSrc?: string;
+  name: string;
+  talkTitle?: string;
+  talkAbstract?: string;
+}
+
+export const SpeakerModal: React.FC<SpeakerModalProps> = ({ id, imageSrc, name, talkTitle, talkAbstract }) => {
+  return (
+    <div>
+      <input type="checkbox" id={id} className="peer hidden" />
+      <div className="z-50 fixed inset-0 items-center justify-center peer-checked:flex hidden">
+        <div className="w-[90%] md:max-w-4xl bg-gray-4 text-white p-6 shadow-lg rounded-2xl shadow-button-background-tertiary-hover">
+          <div className="flex justify-end">
+            <label htmlFor={id} className="cursor-pointer">
+              <CloseIcon />
+            </label>
+          </div>
+          <div className="flex flex-col md:flex-row gap-6">
+            {/* Speaker Image */}
+            <div className="flex-shrink-0">
+              <div className="relative w-48 h-48 rounded-lg overflow-hidden bg-gradient-to-br from-blue-500 to-purple-600 shadow-lg mx-auto">
+                {imageSrc ? (
+                  <img
+                    src={imageSrc}
+                    alt={name}
+                    className="w-full h-full object-cover object-center"
+                    onError={(e) => {
+                      const target = e.target as HTMLImageElement;
+                      target.style.display = 'none';
+                      const fallback = target.nextElementSibling as HTMLElement;
+                      if (fallback) fallback.style.display = 'flex';
+                    }}
+                  />
+                ) : null}
+                <div
+                  className="w-full h-full flex items-center justify-center text-white"
+                  style={{ display: imageSrc ? 'none' : 'flex' }}
+                >
+                  <span className="text-6xl opacity-70">👤</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex-1 space-y-4">
+              <Subtitle size='lg'>{name}</Subtitle>
+
+              {talkTitle && (
+                <div>
+                  <h4 className="text-lg font-medium text-white">{talkTitle}</h4>
+                </div>
+              )}
+
+              {talkAbstract && (
+                <div>
+                  <p className="text-gray-400 leading-relaxed">
+                    {talkAbstract}
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SpeakerModal;

--- a/shared/react-components/src/modal/index.tsx
+++ b/shared/react-components/src/modal/index.tsx
@@ -37,3 +37,5 @@ export default function Modal({ id, image, title, buttonText, richText, buttonLi
     </div>
   );
 }
+
+export { SpeakerModal } from './SpeakerModal';

--- a/shared/react-components/src/sections/SpeakersSection/index.tsx
+++ b/shared/react-components/src/sections/SpeakersSection/index.tsx
@@ -1,20 +1,15 @@
+'use client';
+
+import { SpeakerModal } from '../../modal';
 import Subtitle from '../../subtitle';
-import SpeakerCard, { SocialNetwork } from '../../speaker-card';
-import TwitterIcon from '../../icons/Twitter';
-import InstagramIcon from '../../icons/Instagram';
-import LinkedinIcon from '../../icons/Linkedin';
 import Paragraph from '../../paragraph';
 
 export interface Speaker {
   id: string;
   imageSrc: string;
-  title: string;
-  description: string;
-  socialNetworks: {
-    url: string;
-    iconName: string;
-  }[];
-  tags?: string[];
+  name: string;
+  talkTitle: string;
+  talkAbstract?: string;
 }
 
 export interface SpeakersSectionProps {
@@ -23,18 +18,11 @@ export interface SpeakersSectionProps {
   description?: string;
 }
 
-const iconsByName: Record<string, typeof TwitterIcon> = {
-  "Twitter": TwitterIcon,
-  "Instagram": InstagramIcon,
-  "Linkedin": LinkedinIcon
-}
-
 export default function SpeakersSection({
   speakers,
   description,
   title = "Speakers"
 }: Readonly<SpeakersSectionProps>) {
-
   return (
     <section className="bg-gray-4">
       <div className="flex flex-col items-center gap-8 container-custom py-12 px-4">
@@ -46,27 +34,39 @@ export default function SpeakersSection({
           </Paragraph>
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-16 md:gap-12">
-
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-8 max-w-7xl">
           {speakers?.map((speaker) => {
-            const socialNetworks: SocialNetwork[] = speaker.socialNetworks?.map(({ url, iconName }) => {
-              const Icon = iconsByName[iconName]
-              return {
-                url,
-                icon: Icon ? <Icon /> : null
-              }
-            })
+            const speakerId = `speaker-${speaker.id}`;
 
             return (
-              <SpeakerCard
-                key={speaker.id}
-                imageSrc={speaker.imageSrc}
-                title={speaker.title}
-                description={speaker.description}
-                socialNetworks={socialNetworks}
-                tags={speaker.tags ?? []}
-              />
-            )
+              <div key={speaker.id} className="flex flex-col items-center text-center space-y-3">
+
+                <SpeakerModal
+                  id={speakerId}
+                  imageSrc={speaker.imageSrc}
+                  name={speaker.name}
+                  talkTitle={speaker.talkTitle}
+                  talkAbstract={speaker.talkAbstract}
+                />
+
+                <label htmlFor={speakerId} className="cursor-pointer hover:opacity-80 transition-opacity duration-300 flex flex-col items-center">
+
+                  <div className="relative w-32 h-32 rounded-full overflow-hidden shadow-lg">
+                    {speaker.imageSrc ? (
+                      <img
+                        src={speaker.imageSrc}
+                        alt={speaker.name}
+                        className="w-full h-full object-cover object-center hover:scale-105 transition-transform duration-300"
+                      />
+                    ) : null}
+                  </div>
+
+                  <div className='mt-4'>
+                    <h3 className="font-semibold text-lg text-white leading-tight">{speaker.name}</h3>
+                  </div>
+                </label>
+              </div>
+            );
           })}
         </div>
       </div>


### PR DESCRIPTION
This pull request introduces a new feature to display speaker information for the "Speakers" section in the DevOpsDays Lima 2025 website. It includes changes to add a dedicated service for fetching and transforming speaker data, updates to the dependency injection container, and modifications to the UI components to support speaker profiles and modal dialogs. Below are the most important changes grouped by theme:

### Backend Integration for Speaker Data:
- **Speaker Data Service**: Added `SpeakersDataService` to fetch and cache speaker data from an external API, transform it into a usable format, and provide methods for retrieving sections and modals. (`apps/new-web/src/services/speakers/SpeakersDataService.ts`)
- **Container Configuration**: Registered `SpeakersDataService` in the dependency injection container with the identifier `ISpeakersData`. (`apps/new-web/src/globals/container.ts`)
- **Container Identifiers**: Added `ISpeakersData` to the `ContainerIdentifiers` enum. (`apps/new-web/src/globals/identifiers.ts`)

### Data Models and Types:
- **Speaker and Talk Types**: Defined interfaces for API data (`ApiSpeaker`, `ApiTalk`, `ApiScheduleData`) and transformed speaker data (`SpeakerWithTalk`). (`apps/new-web/src/services/speakers/types.ts`)

### Frontend Components for Speakers:
- **Speaker Modal**: Created a reusable modal component (`SpeakerModal`) to display detailed information about a speaker, including their name, talk title, and abstract. (`shared/react-components/src/modal/SpeakerModal.tsx`)
- **Speakers Section**: Updated the `SpeakersSection` component to display speaker profiles in a responsive grid and integrate the `SpeakerModal` for detailed views. (`shared/react-components/src/sections/SpeakersSection/index.tsx`) [[1]](diffhunk://#diff-aa63a2b2f7ba000188623f573804240d89927033ae3835e45b515179adac1b58R1-R12) [[2]](diffhunk://#diff-aa63a2b2f7ba000188623f573804240d89927033ae3835e45b515179adac1b58L49-R69)

### Data Transformation Logic:
- **Transformer Updates**: Enhanced the `transformer` function to handle both Contentful-based and API-based speaker data, ensuring compatibility with different data sources. (`apps/new-web/src/widgets/speakers/transformer.ts`)

These changes collectively enable the "Speakers" section to dynamically fetch, transform, and display speaker data, improving the user experience and showcasing the event's speakers effectively.…al display